### PR TITLE
Use more appropriate ssl ciphers to use with http2

### DIFF
--- a/nginx/templates/default.conf.jinja
+++ b/nginx/templates/default.conf.jinja
@@ -18,10 +18,8 @@ server {
   ssl_certificate /etc/ssl/certs/{{ ssl.cert }};
   ssl_certificate_key /etc/ssl/private/{{ ssl.key }};
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-  {%- if not ssl.http2|default(False) %}
-  ssl_ciphers "AES256+EECDH:AES256+EDH";
+  ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
   ssl_prefer_server_ciphers on;
-  {%- endif %}
   ssl_session_cache shared:SSL:10m;
   ssl_session_timeout 10m;
 

--- a/nginx/templates/redirect.conf.jinja
+++ b/nginx/templates/redirect.conf.jinja
@@ -20,7 +20,7 @@ server {
   ssl_certificate /etc/ssl/certs/{{ ssl.cert }};
   ssl_certificate_key /etc/ssl/private/{{ ssl.key }};
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-  ssl_ciphers "AES256+EECDH:AES256+EDH";
+  ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
   ssl_session_timeout 10m;


### PR DESCRIPTION
This allows for A+ ratings when http2 is enabled.
