### PR TITLE
Fix for Salt 2016.3: Either use key_url or keyserver not both.

### DIFF
--- a/nginx/repo.sls
+++ b/nginx/repo.sls
@@ -13,8 +13,6 @@ nginx_repo:
     {%- endif %}
     - dist: {{ lsb_codename }}
     - file: /etc/apt/sources.list.d/nginx.list
-    - keyid: 7BD9BF62
     - key_url: http://nginx.org/keys/nginx_signing.key
-    - keyserver: keyserver.ubuntu.com
     - require_in:
       - pkg: nginx


### PR DESCRIPTION
This resolves the following issue introduced in Salt 2016.3.0:

```
          ID: nginx_repo
    Function: pkgrepo.managed
        Name: deb http://nginx.org/packages/ubuntu/ trusty nginx
      Result: False
     Comment: You may not use both "keyid"/"keyserver" and "key_url" argument.
     Started: 08:01:59.092297
    Duration: 1.746 ms
     Changes:   
```

This change has no adverse affects on versions prior to 2016.3.0.
