### PR TITLE
Feature/extra proxy config

### DIFF
--- a/nginx/templates/proxy.conf.jinja
+++ b/nginx/templates/proxy.conf.jinja
@@ -31,4 +31,5 @@ server {
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
+  {{ extra_config|default([])|join("\n")|indent(2) }}
 }

--- a/nginx/templates/proxy.conf.jinja
+++ b/nginx/templates/proxy.conf.jinja
@@ -29,6 +29,7 @@ server {
     proxy_set_header        Host            $host;
     proxy_set_header        X-Real-IP       $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    {{ proxy_params|default([])|join("\n")|indent(3) }}
   }
 
   {{ extra_config|default([])|join("\n")|indent(2) }}


### PR DESCRIPTION
### Ticket
I wanted to forward gzip compression from my proxy host. Turns out you'll need [an additional configuration parameter](http://reinout.vanrees.org/weblog/2015/11/19/nginx-proxy-gzip.html) in the "proxy pass" vhost to achieve this.

### What has been done
- Added two optional configuration's to the proxy template

### How to test
I might require some help around this area. Because this formula is locally used in combination with the [vhosting formulla](https://github.com/Enrise/vhosting-formula/blob/0877cdafdfc51312ed18697954b223e66e499130/vhosting/resources/vhost.sls#L35). I'm not sure how to proof that these changes work and do not create BC breaks. 

### Notes
- off topic discussion: what would be the impact of adding `proxy_http_version 1.1` as a default to all proxies?