### PR TITLE
Fix invalid number of arguments for gzip_buffers directive

### DIFF
--- a/nginx/templates/_gzip.jinja
+++ b/nginx/templates/_gzip.jinja
@@ -5,7 +5,7 @@
   gzip_http_version {{ configurable(gzip.options, 'http_version', '1.1') }};
   gzip_comp_level {{ configurable(gzip.options, 'comp_level', '2') }};
   gzip_min_length {{ configurable(gzip.options, 'min_length', '1100') }};
-  gzip_buffers {{ configurable(gzip.options,'buffers','32 4k|16 8k') }};
+  gzip_buffers {{ configurable(gzip.options,'buffers','32 4k') }};
   gzip_proxied {{ configurable(gzip.options, 'proxied', 'any') }};
   gzip_vary {{ configurable(gzip.options, 'vary', 'off') }};
   gzip_static {{ configurable(gzip.options, 'static', 'off') }};


### PR DESCRIPTION
This resolves the following issue:
```nginx: [emerg] invalid number of arguments in "gzip_buffers" directive in /etc/nginx/sites-enabled/50-example.com.conf```