### PR TITLE
Drop TLSv1

### DIFF
--- a/nginx/templates/_ssl.jinja
+++ b/nginx/templates/_ssl.jinja
@@ -9,7 +9,7 @@
   # Enable SSL
   ssl_certificate /etc/ssl/certs/{{ ssl.cert }};
   ssl_certificate_key /etc/ssl/private/{{ ssl.key }};
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.1 TLSv1.2;
   ssl_ciphers EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;


### PR DESCRIPTION
Whoops! we missed the international deadline of removing the ~~good~~ old SSL/EarlyTLS versions. Better late then never.

Context: https://blog.pcisecuritystandards.org/migrating-from-ssl-and-early-tls
Song: https://youtu.be/C3LehTO7kd8?t=1m3s

### What has been done
- Removed TLS1 from the nginx SSL snippet