### PR TITLE
Small indenting fix in the default vhost template file

### DIFF
--- a/nginx/templates/default.conf.jinja
+++ b/nginx/templates/default.conf.jinja
@@ -35,7 +35,7 @@ server {
 
   location / {
       try_files {{ try_files|default('$uri $uri/ /index.php?$args') }};
-      {{ extra_location_config|default([])|join("\n")|indent(4) }}
+      {{ extra_location_config|default([])|join("\n")|indent(6) }}
   }
 
   {%- if logdir is defined %}


### PR DESCRIPTION
Small fix for those cases when you want to add extra config to the docroot part of the vhost.

Found this when configuring a vhost for a QA environment to be only accessible from the local network whilst still having the HTTP port publicly available for the certbot to request new Let's Encrypt certificates.

Before:

```
<vhosting stuff>

  location / {
      try_files $uri $uri/ /index.php?$args;
      allow 172.16.0.0/12;
    deny all;
  }

<more vhosting stuff>
```

after

```
<vhosting stuff>

  location / {
      try_files $uri $uri/ /index.php?$args;
      allow 172.16.0.0/12;
      deny all;
  }

<more vhosting stuff>
```