### PR TITLE
Add pillar config to add config directives to the nginx configuration

### DIFF
--- a/nginx/conf.sls
+++ b/nginx/conf.sls
@@ -111,3 +111,13 @@ install_placeholder:
 {%- endif %}
 
 {%- endif %}
+
+{%- if salt['pillar.get']('nginx:config:extra_config', [])|length > 0 %}
+{{ nginx_map.dirs.config }}/conf.d/extra_config.conf:
+  file.managed:
+    - contents_pillar: nginx:config:extra_config
+    - require:
+      - pkg: nginx
+    - watch_in:
+      - service: nginx    
+{%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,15 @@ nginx:
       - 8.8.8.8
       - 8.8.4.4
 
+    # Extra configs to add to nginx
+    extra_config:
+      - '# Increase resolver timeout'
+      - 'resolver_timeout 35s;'
+      - |
+        # Allow bigger URI paths and headers
+        client_header_buffer_size 128k;
+        large_client_header_buffers 16 1024k;
+
   # Install a placeholder as default vhost
   #placeholder:
   #  install: True


### PR DESCRIPTION
This PR adds an optional `extra_config` pillar entry to allow for inserting directives into the nginx configuration file, without the need for creating a `conf.d` file.