### PR TITLE
👷 Add tests on Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
 before_install:
   - sudo apt-get update
-  - curl -L http://bootstrap.saltstack.org | sudo -E sh -s -- stable
+  - curl -L http://bootstrap.saltstack.org | sudo -E sh -s -- stable 2019.2.0
 
 install:
   - sudo mkdir -p /srv && sudo ln -sfn $PWD /srv/formula

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,20 @@ env:
     - BS_PIP_ALLOWED=1
     - BS_ECHO_DEBUG=1
     - STATE=nginx
-  matrix:
-    - SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/stable --file-root=$PWD"
-    - SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
 
 matrix:
   include:
     - python: 2.7
-      env: PYTHONVERSION="python2.7"
+      env: PYTHONVERSION="python2.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/stable --file-root=$PWD"
+    - python: 2.7
+      env: PYTHONVERSION="python2.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
     - python: 3.7
-      env: PYTHONVERSION="python3.7"
+      env: PYTHONVERSION="python3.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/stable --file-root=$PWD"
+    - python: 3.7
+      env: PYTHONVERSION="python3.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
   allow_failures:
-    - env: SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
+    - env: PYTHONVERSION="python2.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
+    - env: PYTHONVERSION="python3.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 dist: bionic
-python:
-- '2.7'
-- '3.7'
+#python:
+#- '2.7'
+#- '3.7'
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '3.7'
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: bionic
 python:
 - '2.7'
 - '3.7'
@@ -13,12 +14,17 @@ env:
     - SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
 
 matrix:
+  include:
+    - python: 2.7
+      env: PYTHONVERSION="python2.7"
+    - python: 3.7
+      env: PYTHONVERSION="python3.7"
   allow_failures:
     - env: SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
 
 before_install:
   - sudo apt-get update
-  - curl -L http://bootstrap.saltstack.org | sudo -E sh -s -- stable 2019.2.0
+  - curl -L http://bootstrap.saltstack.org | sudo -E sh -s -- -x ${PYTHONVERSION} stable 2019.2.0
 
 install:
   - sudo mkdir -p /srv && sudo ln -sfn $PWD /srv/formula

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,16 @@ env:
 matrix:
   include:
     - python: 2.7
-      env: PYTHONVERSION="python2.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/stable --file-root=$PWD"
+      env: PYTHONVERSION=python2.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/stable --file-root=$PWD"
     - python: 2.7
-      env: PYTHONVERSION="python2.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
+      env: PYTHONVERSION=python2.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
     - python: 3.7
-      env: PYTHONVERSION="python3.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/stable --file-root=$PWD"
+      env: PYTHONVERSION=python3.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/stable --file-root=$PWD"
     - python: 3.7
-      env: PYTHONVERSION="python3.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
+      env: PYTHONVERSION=python3.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
   allow_failures:
-    - env: PYTHONVERSION="python2.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
-    - env: PYTHONVERSION="python3.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
+    - env: PYTHONVERSION=python2.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
+    - env: PYTHONVERSION=python3.7 SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=.salt/pillar/mainline --file-root=$PWD"
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 dist: bionic
-#python:
-#- '2.7'
-#- '3.7'
 
 env:
   global:


### PR DESCRIPTION
Add tests for Python3 based salt-minion + test on Ubuntu 18.04 instead of 16.04 to match general usage.