### PR TITLE
Pin Salt version to current stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 
 before_install:
   - sudo apt-get update
-  - curl -L http://bootstrap.saltstack.org | sudo -E sh -s -- stable
+  - curl -L http://bootstrap.saltstack.org | sudo -E sh -s -- stable 2019.2.0
 
 install:
   - sudo mkdir -p /srv && sudo ln -sfn $PWD /srv/formula


### PR DESCRIPTION
Pin salt to 2019.2.0 until 2019.2.2 is released with the fix for TemplateError